### PR TITLE
Fix URL normalization in boot.js and GitHub Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,7 +38,7 @@ jobs:
           APP_VERSION: ${{ github.sha }}
           ENV: production
           APP_ENV: production
-          BASE_URL: /sfscheduler/
+          BASE_URL: /sfscheduler
         run: |
           echo "BACKEND: $BACKEND"
           echo "SUPABASE_URL: $SUPABASE_URL"

--- a/boot.js
+++ b/boot.js
@@ -88,7 +88,7 @@
   let mode = window.CONFIG?.BUILD_MODE;
   if (!mode){
     try {
-      const baseUrl = window.CONFIG?.BASE_URL || './dist';
+      const baseUrl = (window.CONFIG?.BASE_URL || './dist').replace(/\/$/, '') || './dist';
       const res = await fetch(baseUrl + '/manifest.json',{ cache:'no-store' });
       if (res.ok){ mode='dist'; window.__BUILD_MANIFEST__ = await res.json(); }
       else mode='dev';
@@ -96,7 +96,7 @@
   }
 
   if (mode==='dist'){
-    const baseUrl = window.CONFIG?.BASE_URL || './dist';
+    const baseUrl = (window.CONFIG?.BASE_URL || './dist').replace(/\/$/, '') || './dist';
     const manifest = window.__BUILD_MANIFEST__ || (await (await fetch(baseUrl + '/manifest.json')).json());
   if (manifest?.version) { window.__APP_VERSION__ = manifest.version; }
     try { await loadDist(manifest); } catch(e){ originalWarn('[boot] dist load failed – falling back to dev', e); await loadDev(); }


### PR DESCRIPTION
- Normalize BASE_URL by removing trailing slashes consistently in boot.js
- Fix GitHub Actions to use BASE_URL=/sfscheduler (no trailing slash)
- Prevents double slash URLs like /sfscheduler//manifest.json
- Ensures manifest.json loads from correct path /sfscheduler/manifest.json
- Both mode detection and production loading now use same URL pattern