### PR TITLE
Debug fix: Explicitly enable generateScheduleBtn in lock fallback

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,7 +84,15 @@ function initApp(){
             if (!currentLockOwner){
                 currentLockOwner = TAB_ID;
                 showLockStatus();
-                try { console.info('[lock] self-assigned (no competing tabs detected)'); } catch {}
+                try { 
+                    console.info('[lock] self-assigned (no competing tabs detected)'); 
+                    // Also explicitly enable the generate button
+                    const btn = document.getElementById('generateScheduleBtn');
+                    if (btn && btn.disabled) {
+                        btn.disabled = false;
+                        console.info('[lock] enabled generateScheduleBtn');
+                    }
+                } catch {}
             }
         }, 300);
         // Fallback via storage events if BroadcastChannel unavailable


### PR DESCRIPTION
- Added explicit button.disabled = false in 300ms lock fallback
- Added console logging to debug lock acquisition
- Should resolve disabled button issue on GitHub Pages
- Button now gets enabled when tab claims edit lock automatically