### PR TITLE
app state split-brain fix and holiday services logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { appState } from './modules/state.js';
+import { appState } from '@state';
 import { ScheduleUI } from './ui/scheduleUI.js';  // Updated path
 import { EventHandler } from './ui/eventHandlers.js';  // Updated path
 import { APP_CONFIG, SHIFTS } from './modules/config.js';

--- a/modules/academicTerms.js
+++ b/modules/academicTerms.js
@@ -1,4 +1,4 @@
-import { appState } from './state.js';
+import { appState } from '@state';
 import { APP_CONFIG } from './config.js';
 import { toLocalISODate } from '../utils/dateUtils.js';
 

--- a/modules/eventHandlers.js
+++ b/modules/eventHandlers.js
@@ -1,4 +1,4 @@
-import { appState } from './state.js';
+import { appState } from '@state';
 import { SchedulingEngine } from '../scheduler.js';
 // This file in modules is unused by the app; keep paths correct to avoid runtime import failures if referenced
 import { ModalManager } from '../ui/modalManager.js';

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,5 +1,5 @@
 import { APP_CONFIG, SHIFTS } from './modules/config.js';
-import { appState } from './modules/state.js';
+import { appState } from '@state';
 import { parseYMD } from './utils/dateUtils.js';
 import { getStudentWeeklyCapSync } from './modules/academicTerms.js';
 

--- a/services/scheduleService.js
+++ b/services/scheduleService.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 
 // Placeholder schedule service for future Supabase adapter integration.
 export const scheduleService = {

--- a/services/staffService.js
+++ b/services/staffService.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 
 // Minimal staff service (local adapter); to be swapped with Supabase implementation later.
 export const staffService = {

--- a/src/api/public.js
+++ b/src/api/public.js
@@ -12,7 +12,7 @@
  * - Audit logging for all public API calls
  */
 
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 import { APP_CONFIG } from '../../modules/config.js';
 
 class PublicAPI {

--- a/src/services/HolidayService.js
+++ b/src/services/HolidayService.js
@@ -1,4 +1,4 @@
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 import { APP_CONFIG } from '../../modules/config.js';
 
 export function createHolidayService(){
@@ -90,6 +90,9 @@ export function createHolidayService(){
         }
 
         console.log(`Loaded ${stateHolidays.length} holidays for ${year}:`, appState.holidays[yearStr]);
+        
+        // Mark log for split-brain detection
+        console.log('[holidays][writer] mark=', window.__STATE_MARK__, appState.holidays[String(year)]);
         
         // Double-check the data is still there after save
         setTimeout(() => {

--- a/src/services/ReportService.js
+++ b/src/services/ReportService.js
@@ -1,4 +1,4 @@
-import { appState as defaultAppState } from '../../modules/state.js';
+import { appState as defaultAppState } from '@state';
 import { SHIFTS, APP_CONFIG } from '../../modules/config.js';
 import { parseYMD } from '../../utils/dateUtils.js';
 

--- a/src/services/VacationService.js
+++ b/src/services/VacationService.js
@@ -1,4 +1,4 @@
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 
 export function createVacationService(store){
   return {

--- a/src/storage/HydratingStore.js
+++ b/src/storage/HydratingStore.js
@@ -1,4 +1,4 @@
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 
 // Wraps an async adapter (SupabaseAdapter) and provides a synchronous API compatible with LocalStorageAdapter
 // by maintaining an in-memory mirror (appState) and performing remote writes asynchronously.

--- a/src/storage/LocalStorageAdapter.js
+++ b/src/storage/LocalStorageAdapter.js
@@ -1,4 +1,4 @@
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 
 // Local adapter proxies to in-memory appState while coordinating persistence via appState.save().
 export class LocalStorageAdapter {

--- a/src/utils/backup.js
+++ b/src/utils/backup.js
@@ -1,5 +1,5 @@
 // Backup & restore utilities (Sprint 4)
-import { appState } from '../../modules/state.js';
+import { appState } from '@state';
 
 const DURABLE_KEYS = ()=> Object.keys(appState).filter(k=> appState.isDurableKey && appState.isDurableKey(k));
 

--- a/test/hydratingStore.test.js
+++ b/test/hydratingStore.test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../src/services/index.js';
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 
 (async function(){
   const cfg = (typeof window!=='undefined'? window.__CONFIG__ : global.__CONFIG__) || {};

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,5 +1,5 @@
 import { SchedulingEngine } from '../scheduler.js';
-import { appState } from '../modules/state.js';  // Updated path
+import { appState } from '@state';  // Updated path
 import { TestDataGenerator, TestAssertions } from '../utils.js';  // Updated path
 
 const tests = {

--- a/ui/appUI.js
+++ b/ui/appUI.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js'; // TODO remove direct non-staff usage later
+import { appState } from '@state'; // TODO remove direct non-staff usage later
 import { APP_CONFIG, SHIFTS } from '../modules/config.js';
 import { toLocalISOMonth, toLocalISODate, pad2, parseYMD } from '../utils/dateUtils.js';
 // Add audit message helper

--- a/ui/eventHandlers.js
+++ b/ui/eventHandlers.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 import { ModalManager } from './modalManager.js';
 import { ScheduleValidator } from '../validation.js';
 import { SchedulingEngine } from '../scheduler.js';

--- a/ui/overtimeRequests.js
+++ b/ui/overtimeRequests.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 import { SHIFTS } from '../modules/config.js';
 import { parseYMD } from '../utils/dateUtils.js';
 import { ScheduleValidator } from '../validation.js';

--- a/ui/scheduleUI.js
+++ b/ui/scheduleUI.js
@@ -1,5 +1,5 @@
 import { APP_CONFIG, SHIFTS } from '../modules/config.js';
-import { appState } from '../modules/state.js';
+import { appState } from '@state';
 import { SchedulingEngine } from '../scheduler.js';
 import { ScheduleValidator } from '../validation.js';
 import { parseYMD } from '../utils/dateUtils.js';
@@ -91,6 +91,8 @@ export class ScheduleUI {
                         console.log(`Successfully loaded holidays for ${year}`);
                         // Log the actual holiday data
                         const holidays = window.appState?.holidays?.[String(year)] || {};
+                        // Mark log for split-brain detection
+                        console.log('[holidays][reader] mark=', window.__STATE_MARK__, appState.holidays[String(year)]);
                         console.log(`Holiday data for ${year}:`, holidays);
                         const oct3 = holidays['2025-10-03'];
                         if (oct3) {

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,4 +1,4 @@
-import { appState } from '../modules/state.js';  // Fixed relative path from utils/
+import { appState } from '@state';  // Fixed relative path from utils/
 import { ROLE_TYPES } from '../types.js';
 
 /**

--- a/validation.js
+++ b/validation.js
@@ -1,5 +1,5 @@
 import { APP_CONFIG, SHIFTS } from './modules/config.js';  // Updated path
-import { appState } from './modules/state.js';  // Updated path and name
+import { appState } from '@state';  // Updated path and name
 import { getWeekNumber, parseShiftTime, parseYMD } from './utils/dateUtils.js';
 import { getStudentWeeklyCapSync } from './modules/academicTerms.js';
 


### PR DESCRIPTION
Added UUID marking system to [state.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to detect multiple singleton instances
Added window.appState unification logic with detailed logging
Added runtime safety guard to force unification if split-brain is detected
Writer/Reader Mark Logging

Holiday Writer: Added mark logging in [HolidayService.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after holidays are saved
Schedule Reader: Added mark logging in [scheduleUI.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) before holiday data is read
Both logs will show if they're accessing the same or different state instances
ESBuild Alias Plugin

Created alias-state plugin in [build.mjs](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to force single import resolution
All [state.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) imports now resolve to the same absolute path: [state.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added @state alias as preferred import pattern
Plugin logs show successful resolution of all imports
Import Normalization

Systematically replaced all [state.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) import variations across 20+ files
Converted from patterns like:
'./modules/state.js'
'../modules/state.js'
'../../modules/state.js'
To unified: '@state'


Single State Mark: Only one [state] attach window.appState mark=... message
Matching Marks: Both writer and reader logs showing the same UUID mark
Holiday Data Present: Reader logs showing holidays object with 10+ entries instead of {}
October 3rd Success: ✅ October 3rd found in data instead of the previous error

Main app at http://localhost:8080 - should now show holidays correctly
Verification test at http://localhost:8080/test-holiday-fix-verification.html - provides detailed diagnostics
The esbuild plugin is working correctly (build logs show successful alias resolution), and all imports are now unified through the @state alias. This should resolve the dual singleton issue that was causing holidays to be written to one state instance but read from another.

The fix maintains the runtime window.appState override as a safety net, ensuring even if any import slips through, the global reference remains unified! 