### PR TITLE
Fix button visibility issue - set schedule tab as default active

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,9 +123,9 @@
     <!-- Backend fallback banner now injected dynamically via __banner when needed -->
 
         <div class="tabs">
-            <button class="tab active" data-tab="staff">Personalverwaltung</button>
+            <button class="tab" data-tab="staff">Personalverwaltung</button>
             <button class="tab" data-tab="availability">Verfügbarkeiten</button>
-            <button class="tab" data-tab="schedule">Dienstplan</button>
+            <button class="tab active" data-tab="schedule">Dienstplan</button>
             <button class="tab" data-tab="vacation">Urlaub</button>
             <button class="tab" data-tab="reports">Berichte</button>
             <button class="tab" data-tab="monitoring">Monitoring</button>
@@ -133,7 +133,7 @@
         </div>
 
         <div class="tab-content">
-            <div id="staff-tab" class="section active">
+            <div id="staff-tab" class="section">
                 <h2>Personalverwaltung</h2>
                 <div class="form-group staff-card">
                     <h3 id="staffFormTitle">Neue Arbeitskraft hinzufügen</h3>
@@ -218,7 +218,7 @@
                 <div id="availabilityForm"><p>Bitte Mitarbeiter und Monat auswählen.</p></div>
             </div>
 
-            <div id="schedule-tab" class="section">
+            <div id="schedule-tab" class="section active">
                 <h2>Dienstplan</h2>
                 <div class="controls form-row grid-cols-2fr-auto gap-8 align-center">
                     <select id="scheduleMonth"></select>

--- a/ui/scheduleUI.js
+++ b/ui/scheduleUI.js
@@ -568,12 +568,18 @@ export class ScheduleUI {
     }
 
     bindDelegatesOnce(){
-        if (this._delegatesBound) return;
+        if (this._delegatesBound) {
+            console.log('[bindDelegatesOnce] already bound, skipping');
+            return;
+        }
+        console.log('[bindDelegatesOnce] setting up click delegation');
         this._delegatesBound = true;
         // Toolbar & calendar delegation
         document.addEventListener('click', (e)=>{
+            console.log('[delegation] document click detected, target=', e.target);
             const btn = e.target.closest('button');
             if (btn){
+                console.log('[delegation] button click detected, id=', btn.id);
                 const id = btn.id;
                 if (id === 'showHolidaysBtn'){
                     try { (window.modalManager||window).open ? window.modalManager.open('holidaysModal') : window.showModal?.('holidaysModal'); }


### PR DESCRIPTION
- Changed default active tab from 'staff' to 'schedule'
- Schedule buttons were hidden because they're in an inactive tab
- CSS rule .section { display: none } hides inactive sections
- Now buttons are visible on app startup for easier testing